### PR TITLE
Add riscv64 generic build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   * **Rust** Bindings. Access TurboPFor **incl. SSE/AVX2/Neon!** from Rust
   * :+1: **Java** Critical Natives/JNI. Access TurboPFor **incl. SSE/AVX2/Neon!** from Java as fast as calling from C
   * :sparkles: **FULL** range 8/16/32/64 bits scalar + 16/32/64 bits SIMD functions
+  * `riscv64` currently uses the existing generic/scalar path and does not enable x86 SIMD or AVX2 code paths unless a dedicated RISC-V backend is added.
   * No other "Integer Compression" compress/decompress faster
   * :sparkles: Direct Access, **integrated** (SIMD/AVX2) FOR/delta/Delta of Delta/Zigzag for sorted/unsorted arrays
 * **For/PFor/PForDelta**

--- a/include/ic_.h
+++ b/include/ic_.h
@@ -37,6 +37,13 @@ typedef unsigned long long uint64_t;
 #endif
 #include <stddef.h>
 
+//------------------------- Target architecture --------------------------------
+  #if defined(__riscv)
+    #define IC_ARCH_RISCV 1
+  #elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__)
+    #define IC_ARCH_X86 1
+  #endif
+
 //------------------------- Compiler ------------------------------------------
   #if defined(__GNUC__)
 #include <stdint.h>
@@ -59,7 +66,7 @@ static ALWAYS_INLINE unsigned short bswap16(unsigned short x) { return __builtin
 #define popcnt32(_x_)   __builtin_popcount(_x_)
 #define popcnt64(_x_)   __builtin_popcountll(_x_)
 
-    #if defined(__i386__) || defined(__x86_64__)
+    #if defined(IC_ARCH_X86)
 //x,__bsr32:     1:0,2:1,3:1,4:2,5:2,6:2,7:2,8:3,9:3,10:3,11:3,12:3,13:3,14:3,15:3,16:4,17:4,18:4,19:4,20:4,21:4,22:4,23:4,24:4,25:4,26:4,27:4,28:4,29:4,30:4,31:4,32:5,...
 //x,  bsr32: 0:0,1:1,2:2,3:2,4:3,5:3,6:3,7:3,8:4,9:4,10:4,11:4,12:4,13:4,14:4,15:4,16:5,17:5,18:5,19:5,20:5,21:5,22:5,23:5,24:5,25:5,26:5,27:5,28:5,29:5,30:5,31:5,32:6,...
 static ALWAYS_INLINE int    __bsr32(               int x) {             asm("bsr  %1,%0" : "=r" (x) : "rm" (x) ); return x; }
@@ -162,7 +169,7 @@ static ALWAYS_INLINE double round(double num) { return (num > 0.0) ? floor(num +
 #define popcnt16(x)  popcnt32(x)
 
 //--------------- Unaligned memory access -------------------------------------
-  #ifdef UA_MEMCPY
+  #if defined(UA_MEMCPY) || defined(IC_ARCH_RISCV)
 #include <string.h>
 static ALWAYS_INLINE unsigned short     ctou16(const void *cp) { unsigned short     x; memcpy(&x, cp, sizeof(x)); return x; } // ua read
 static ALWAYS_INLINE unsigned           ctou32(const void *cp) { unsigned           x; memcpy(&x, cp, sizeof(x)); return x; }
@@ -181,8 +188,7 @@ static ALWAYS_INLINE void               stof64(      void *cp, double           
 static ALWAYS_INLINE void               ltou32(unsigned           *x, const void *cp) { memcpy(x, cp, sizeof(*x)); } // ua read into ptr
 static ALWAYS_INLINE void               ltou64(unsigned long long *x, const void *cp) { memcpy(x, cp, sizeof(*x)); }
 
-  #elif defined(__i386__) || defined(__x86_64__) || \
-    defined(_M_IX86) || defined(_M_AMD64) || _MSC_VER ||\
+  #elif defined(IC_ARCH_X86) || defined(_MSC_VER) ||\
     defined(__powerpc__) || defined(__s390__) ||\
     defined(__ARM_FEATURE_UNALIGNED) || defined(__aarch64__) || defined(__arm__) ||\
     defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__) || \
@@ -198,7 +204,7 @@ static ALWAYS_INLINE void               ltou64(unsigned long long *x, const void
 
 #define ltou32(_px_, _cp_) *(_px_) = *(unsigned *)(_cp_)
 
-    #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || defined(__s390__) || defined(_MSC_VER)
+    #if defined(IC_ARCH_X86) || defined(__powerpc__) || defined(__s390__) || defined(_MSC_VER)
 #define ctou64(_cp_)       (*(uint64_t *)(_cp_))
 #define ctof64(_cp_)       (*(double   *)(_cp_))
 
@@ -248,6 +254,7 @@ struct _PACKED doubleu   { double             d; };
 #define ctou8(_cp_) (*(_cp_))
 //--------------------- wordsize ----------------------------------------------
   #if defined(__64BIT__) || defined(_LP64) || defined(__LP64__) || defined(_WIN64) ||\
+    (defined(__riscv_xlen) && __riscv_xlen == 64) ||\
     defined(__x86_64__) || defined(_M_X64) ||\
     defined(__ia64) || defined(_M_IA64) ||\
     defined(__aarch64__) ||\
@@ -272,7 +279,7 @@ struct _PACKED doubleu   { double             d; };
 #define BZHI8( _u_, _b_)                 BZHI32(_u_, _b_)
 #define BEXTR32(x,start,len)             (((x) >> (start)) & ((1u << (len)) - 1)) //Bit field extract (with register)
 
-    #ifdef __AVX2__
+    #if defined(IC_ARCH_X86) && defined(__AVX2__)
       #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #include <intrin.h>
       #else

--- a/lib/bitutil.c
+++ b/lib/bitutil.c
@@ -533,8 +533,13 @@ uint32_t bitdienc32(uint32_t *in, unsigned n, uint32_t *out, uint32_t start, uin
     *op++ = x;
   }
     #else
-  uint32_t b = 0,*op = out, x, *_ip;
-  BITDE(uint32_t, in, n, mindelta, b |= x; *op++ = x);
+  uint32_t b = 0,*op = out, *_ip;
+  for(_ip = in; _ip != in+n; _ip++) {
+    uint32_t u = *_ip - start - mindelta;
+    start = *_ip;
+    b    |= u;
+    *op++ = u;
+  }
     #endif
   return b;
 }
@@ -824,7 +829,7 @@ void bitxdec32(unsigned *in, unsigned n, unsigned start) {
     *ip++ = (start ^= z);
   }
     #else
-  BITXDEC(uint32_t, 32, in, n);
+  BITXDEC(uint32_t, in, n);
     #endif
 }
 

--- a/lib/include_/conf.h
+++ b/lib/include_/conf.h
@@ -36,6 +36,34 @@ typedef unsigned long long uint64_t;
 #include <stdint.h>
 #endif
 #include <stddef.h>
+
+//------------------------- Target architecture --------------------------------
+  #if defined(__riscv)
+    #define IC_ARCH_RISCV 1
+    #ifdef __AVX2__
+      #undef __AVX2__
+    #endif
+    #ifdef __AVX__
+      #undef __AVX__
+    #endif
+    #ifdef __SSE4_1__
+      #undef __SSE4_1__
+    #endif
+    #ifdef __SSSE3__
+      #undef __SSSE3__
+    #endif
+    #ifdef __SSE3__
+      #undef __SSE3__
+    #endif
+    #ifdef __SSE2__
+      #undef __SSE2__
+    #endif
+    #ifdef __SSE__
+      #undef __SSE__
+    #endif
+  #elif defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__amd64__)
+    #define IC_ARCH_X86 1
+  #endif
 #define __STDC_WANT_IEC_60559_TYPES_EXT__
 #include <float.h>
 #if defined(__clang__) && defined(__is_identifier)
@@ -68,7 +96,7 @@ static ALWAYS_INLINE unsigned short bswap16(unsigned short x) { return __builtin
 #define popcnt32(_x_)   __builtin_popcount(_x_)
 #define popcnt64(_x_)   __builtin_popcountll(_x_)
 
-    #if defined(__i386__) || defined(__x86_64__)
+    #if defined(IC_ARCH_X86)
 //x,__bsr32:     1:0,2:1,3:1,4:2,5:2,6:2,7:2,8:3,9:3,10:3,11:3,12:3,13:3,14:3,15:3,16:4,17:4,18:4,19:4,20:4,21:4,22:4,23:4,24:4,25:4,26:4,27:4,28:4,29:4,30:4,31:4,32:5,...
 //x,  bsr32: 0:0,1:1,2:2,3:2,4:3,5:3,6:3,7:3,8:4,9:4,10:4,11:4,12:4,13:4,14:4,15:4,16:5,17:5,18:5,19:5,20:5,21:5,22:5,23:5,24:5,25:5,26:5,27:5,28:5,29:5,30:5,31:5,32:6,...
 static ALWAYS_INLINE int    __bsr32(               int x) {             asm("bsr  %1,%0" : "=r" (x) : "rm" (x) ); return x; }
@@ -197,8 +225,7 @@ static ALWAYS_INLINE void               stof64(      void *cp, double           
 static ALWAYS_INLINE void               ltou32(unsigned           *x, const void *cp) { memcpy(x, cp, sizeof(*x)); } // ua read into ptr
 static ALWAYS_INLINE void               ltou64(unsigned long long *x, const void *cp) { memcpy(x, cp, sizeof(*x)); }
 
-  #elif defined(__i386__) || defined(__x86_64__) || \
-    defined(_M_IX86) || defined(_M_AMD64) || _MSC_VER ||\
+  #elif defined(IC_ARCH_X86) || defined(IC_ARCH_RISCV) || defined(_MSC_VER) ||\
     defined(__powerpc__) || defined(__s390__) ||\
     defined(__ARM_FEATURE_UNALIGNED) || defined(__aarch64__) || defined(__arm__) ||\
     defined(__ARM_ARCH_4__) || defined(__ARM_ARCH_4T__) || \
@@ -216,7 +243,7 @@ static ALWAYS_INLINE void               ltou64(unsigned long long *x, const void
 
 #define ltou32(_px_, _cp_) *(_px_) = *(unsigned *)(_cp_)
 
-    #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || defined(__s390__) || defined(_MSC_VER)
+    #if defined(IC_ARCH_X86) || defined(IC_ARCH_RISCV) || defined(__powerpc__) || defined(__s390__) || defined(_MSC_VER)
 #define ctou64(_cp_)       (*(uint64_t *)(_cp_))
 #define ctof64(_cp_)       (*(double   *)(_cp_))
 
@@ -271,6 +298,7 @@ struct _PACKED doubleu   { double             d; };
 #define ctou8(_cp_) (*(_cp_))
 //--------------------- wordsize ----------------------------------------------
   #if defined(__64BIT__) || defined(_LP64) || defined(__LP64__) || defined(_WIN64) ||\
+    (defined(__riscv_xlen) && __riscv_xlen == 64) ||\
     defined(__x86_64__) || defined(_M_X64) ||\
     defined(__ia64) || defined(_M_IA64) ||\
     defined(__aarch64__) ||\

--- a/lib/include_/time_.h
+++ b/lib/include_/time_.h
@@ -37,7 +37,7 @@
 #define Sleep(ms) usleep((ms) * 1000)
   #endif
 
-#if defined (__i386__) || defined( __x86_64__ )  // ------------------ rdtsc --------------------------
+#if (defined (__i386__) || defined( __x86_64__ )) && !defined(__riscv)  // ------------------ rdtsc --------------------------
   #ifdef _MSC_VER
 #include <intrin.h> // __rdtsc
   #else

--- a/makefile
+++ b/makefile
@@ -13,6 +13,8 @@
 #           or    "make CODEC1=1 CODEC2=1 ICCODEC=1"
 # aarch64 cross compile
 # export CC=aarch64-linux-gnu-gcc
+# riscv64 cross compile
+# export CC=riscv64-linux-gnu-gcc
 
 #ICCODEC=1
 #AVX2=1
@@ -50,8 +52,12 @@ else
 
 ifneq (,$(findstring aarch64,$(CC)))
   ARCH = aarch64
+else ifneq (,$(findstring riscv64,$(CC)))
+  ARCH = riscv64
 else ifneq (,$(findstring arm64,$(ARCH)))
   ARCH = aarch64
+else ifneq (,$(findstring riscv64,$(ARCH)))
+  ARCH = riscv64
 else ifneq (,$(findstring iPhone,$(ARCH)))
   ARCH = aarch64
   CFLAGS=-DHAVE_MALLOC_MALLOC
@@ -63,6 +69,8 @@ endif
 ifeq ($(ARCH),ppc64le)
   _SSE=-D__SSSE3__
   CFLAGS=-mcpu=power9 -mtune=power9 $(_SSE)
+else ifeq ($(ARCH),riscv64)
+  CFLAGS=-D__riscv=1 -D__riscv_xlen=64
 else ifeq ($(ARCH),aarch64)
   CFLAGS=-march=armv8-a
 ifneq (,$(findstring clang, $(CC)))


### PR DESCRIPTION
## Why

TurboPFor already contains scalar and generic code paths that are suitable as a conservative baseline for `riscv64`, but its current build logic and architecture probing are still x86-centric. When the target is forced to `riscv64`, host x86 SIMD macros can leak into preprocessing, and the makefile does not expose an explicit `riscv64` target path. In addition, two generic fallback code paths in `bitutil.c` have latent compile issues that remain hidden as long as AVX2-oriented builds dominate.

## What changed

- Add explicit `riscv64` handling in `makefile` so `ARCH=riscv64` selects the existing generic/scalar implementation path instead of inheriting x86 tuning.
- Add target-architecture detection helpers in `lib/include_/conf.h` and `include/ic_.h`, and suppress leaked host x86 SIMD builtins when the target is forced to `__riscv`.
- Extend the existing 64-bit target detection to recognize `__riscv_xlen == 64`.
- Keep `riscv64` on the current generic implementation path instead of introducing any new RVV-specific backend.
- Guard the x86 `rdtsc` timer path in `lib/include_/time_.h` so forced `riscv64` builds do not enter x86-specific timing code.
- Fix two generic fallback issues in `lib/bitutil.c` that become visible once the generic `_NAVX2` path is actually compiled for `riscv64`:
  - `bitdienc32` now uses an explicit scalar delta-encode loop in the generic branch.
  - `bitxdec32` now calls the generic `BITXDEC` macro with the correct argument list.
- Update `README.md` to document that `riscv64` currently uses the existing generic/scalar path.

## Verification

- Ran the native build successfully:
  - `gmake -j4 libic.a`
- Confirmed the native x86 build still produces AVX2 objects such as `vp4c_avx2.o`, `vp4d_avx2.o`, `transpose_avx2.o`, `bitpack_avx2.o`, `bitunpack_avx2.o`, and `bitutil_avx2.o`.
- Preprocessed `lib/include_/conf.h` with `-D__riscv=1 -D__riscv_xlen=64` and confirmed it reports `IC_ARCH_RISCV` and `__WORDSIZE 64`, without leaking `IC_ARCH_X86`, `__AVX2__`, `__AVX__`, `__SSE2__`, or `__SSSE3__`.
- Ran the simulated `riscv64` build successfully:
  - `gmake -j4 libic.a ARCH=riscv64 CC=gcc`
- Confirmed the simulated `riscv64` build archives only generic objects and does not include any `*_avx2.o` files.
- Confirmed the simulated `riscv64` compile commands do not use x86-specific tuning flags such as `-march=corei7-avx` or `-march=haswell`.
- Cross-built `libic.a` with the real `riscv64` toolchain in `dockcross/linux-riscv64`.
- Linked a minimal `bitnpack32`/`bitnunpack32` consumer against the produced static library.
- Verified the produced executable with:
  - `file`
  - `readelf -h`
- Ran the resulting binary under `qemu-riscv64` and confirmed round-trip compression/decompression succeeds:
  - `turbopfor-ok packed=10 unpacked=10 last=511`

## Notes

This is a conservative portability patch. It does not add RVV or any other RISC-V SIMD acceleration. The goal is to make `riscv64` select TurboPFor's existing generic implementation path correctly and to keep cross-target validation from inheriting host x86 assumptions.